### PR TITLE
 add readmes and yarn scripts for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+## eventjet-seatmaps-monorepo
+
+### Release package
+
+We have scripts defined in the respective package folders to easily release a new version of the package. These scripts will automatically remove build folders, run the build command, and bump the version.
+
+Use `yarn release:patch`, `yarn release:minor`, or `yarn release:major` to release a new version. After that, you can push the changes to the repository and publish the package using `yarn deploy`.

--- a/packages/seatmaps/README.md
+++ b/packages/seatmaps/README.md
@@ -1,0 +1,50 @@
+## @eventjet/react-seatmaps
+
+This package provides react components to render seatmaps in a ticketing system.
+
+### Installation
+
+```bash
+  yarn add @eventjet/react-seatmaps@0.4.2
+```
+
+
+### Simple Usage Example - Volume
+```javascript
+import React from 'react';
+import { Volume } from '@eventjet/react-seatmaps';
+const component = () => (
+    <Volume
+      x={0},
+      y={0},
+      width={400},
+      height={400},
+      color='#808080',
+      disabled={false}
+      active={false}
+      label="Seat 1"
+  />);
+```
+
+### Usage Example - Volumes + SeatCountBadge 
+
+SeatCountBadge only works with Volumes at the moment
+
+```javascript
+import React from 'react';
+import { Volume } from '@eventjet/react-seatmaps';
+const component = () => (
+    <Volume
+        x={0},
+        y={0},
+        width={400},
+        height={400},
+        color='#808080',
+        disabled={false}
+        active={false}
+        label="Seat 1"
+    />
+        <SeatCountBadge containerWidth={400} count={200} />
+    </Volume>
+  );
+```

--- a/packages/seatmaps/package.json
+++ b/packages/seatmaps/package.json
@@ -26,10 +26,13 @@
         "build:esm": "rollup --config config/rollup.config.js",
         "postbuild": "npx rollup -c ./config/rollup.config.js",
         "watch": "npx tsc-watch --onSuccess \"yarn run postbuild\" -p ./config",
-        "predeploy": "yarn run build",
-        "deploy": "yarn publish",
         "storybook": "start-storybook -p 6006",
-        "build-storybook": "build-storybook"
+        "build-storybook": "build-storybook",
+        "predeploy": "yarn run build",
+        "release:patch": "yarn clean && yarn run build && npm version patch",
+        "release:minor": "yarn clean && yarn run build && npm version minor",
+        "release:major": "yarn clean && yarn run build && npm version major",
+        "deploy": "yarn publish"
     },
     "files": [
         "lib"


### PR DESCRIPTION
- eventjet/eventjet-2014#1402

What happened?
- new release scripts defined in package.json to combine tasks in the seatmap-package
- new readme with package Infos in the seatmap-package
- new common readme in root with release-infos
