### PR TITLE
BREAKING: Replace Emotion with static CSS

### DIFF
--- a/packages/seatmaps/README.md
+++ b/packages/seatmaps/README.md
@@ -14,22 +14,11 @@ or
 pnpm add @eventjet/react-seatmaps
 ```
 
-### Peer Dependencies
-
-```bash
-npm install react react-dom @emotion/react @emotion/styled
-```
-
-or
-
-```bash
-pnpm add react react-dom @emotion/react @emotion/styled
-```
-
 ## Quick Start
 
 ```tsx
 import { Seatmap, Block, Row, Seat, Volume, SeatShape } from '@eventjet/react-seatmaps';
+import '@eventjet/react-seatmaps/styles.css';
 
 function MyVenue() {
     return (

--- a/packages/seatmaps/package.json
+++ b/packages/seatmaps/package.json
@@ -7,7 +7,9 @@
         "name": "Rudolph Gottesheim",
         "email": "r.gottesheim@loot.at"
     },
-    "sideEffects": false,
+    "sideEffects": [
+        "**/*.css"
+    ],
     "type": "module",
     "exports": {
         ".": {
@@ -15,6 +17,7 @@
             "import": "./dist/index.js",
             "require": "./dist/index.cjs"
         },
+        "./styles.css": "./dist/index.css",
         "./package.json": "./package.json"
     },
     "main": "./dist/index.cjs",
@@ -39,8 +42,6 @@
         "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
-        "@emotion/react": "^11.10.0",
-        "@emotion/styled": "^11.10.0",
         "@eslint/js": "^9.0.0",
         "@microsoft/api-extractor": "^7.56.2",
         "@storybook/addon-essentials": "^8.4.0",
@@ -66,8 +67,6 @@
         "vitest": "^2.0.0"
     },
     "peerDependencies": {
-        "@emotion/react": "^11.10.0",
-        "@emotion/styled": "^11.10.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
     },

--- a/packages/seatmaps/src/Badge.css
+++ b/packages/seatmaps/src/Badge.css
@@ -1,0 +1,15 @@
+.ej-seatmaps-badge__circle {
+    filter: drop-shadow(-0.25px 1.5px 1px rgb(0 0 0 / 0.2));
+}
+
+.ej-seatmaps-badge__text-overlay-circle {
+    fill: rgba(255, 255, 255, 0.54);
+}
+
+.ej-seatmaps-badge__name {
+    font-family: sans-serif;
+    font-size: 5px;
+    dominant-baseline: middle;
+    text-anchor: middle;
+    fill: black;
+}

--- a/packages/seatmaps/src/Badge.tsx
+++ b/packages/seatmaps/src/Badge.tsx
@@ -1,5 +1,4 @@
-import styled from '@emotion/styled';
-import { textCss } from './textCss';
+import './Badge.css';
 
 /**
  * Props for the {@link Badge} component.
@@ -19,22 +18,6 @@ export interface BadgeProps {
 // radius currently fixed, as the font size would also have to be adjusted when changing the radius
 const CIRCLE_RADIUS = 5;
 
-const Name = styled('text')`
-    ${textCss}
-    dominant-baseline: middle;
-    text-anchor: middle;
-    fill: black;
-`;
-
-const StyledCircle = styled.circle<{ color: string }>`
-    fill: ${({ color }) => color};
-    filter: drop-shadow(-0.25px 1.5px 1px rgb(0 0 0 / 0.2));
-`;
-
-const StyledTextOverlayCircle = styled.circle`
-    fill: rgba(255, 255, 255, 0.54);
-`;
-
 /**
  * A circular badge for displaying numeric counts.
  *
@@ -51,24 +34,27 @@ const StyledTextOverlayCircle = styled.circle`
 export const Badge = ({ x, y, count = 0, color = '#808080' }: BadgeProps) => {
     return (
         <>
-            <StyledCircle
+            <circle
+                className="ej-seatmaps-badge__circle"
                 cx={x}
                 cy={y}
                 r={CIRCLE_RADIUS}
-                color={color}
+                fill={color}
                 filter="url(#f2)"
             />
-            <StyledTextOverlayCircle
+            <circle
+                className="ej-seatmaps-badge__text-overlay-circle"
                 cx={x}
                 cy={y}
                 r={CIRCLE_RADIUS}
             />
-            <Name
+            <text
+                className="ej-seatmaps-badge__name"
                 x={x}
                 y={y}
             >
                 {count}
-            </Name>
+            </text>
         </>
     );
 };

--- a/packages/seatmaps/src/Row.css
+++ b/packages/seatmaps/src/Row.css
@@ -1,0 +1,9 @@
+.ej-seatmaps-row__name {
+    font-family: sans-serif;
+    font-size: 6px;
+    text-anchor: middle;
+    alignment-baseline: central;
+    cursor: inherit;
+    display: block;
+    fill: #707070;
+}

--- a/packages/seatmaps/src/Row.tsx
+++ b/packages/seatmaps/src/Row.tsx
@@ -1,21 +1,10 @@
-import styled from '@emotion/styled';
 import { ReactElement, ReactNode } from 'react';
-import { textCss } from './textCss';
 import { useTransform } from './useTransform';
+import './Row.css';
 
 const isReactElement = (x: unknown): x is ReactElement => {
     return typeof x === 'object' && x !== null && 'props' in x;
 };
-
-const Name = styled('text')`
-    ${textCss}
-    text-anchor: middle;
-    alignment-baseline: central;
-    cursor: inherit;
-    display: block;
-    fill: #707070;
-    font-size: 6px;
-`;
 
 /**
  * Props for the {@link Row} component.
@@ -76,23 +65,25 @@ export const Row = ({ children, leftLabel, rightLabel, x = 0, y = 0 }: RowProps)
     return (
         <g transform={useTransform(x, y)}>
             {leftLabel !== undefined ? (
-                <Name
+                <text
+                    className="ej-seatmaps-row__name"
                     x={-5}
                     y={5}
                     style={leftStyle}
                 >
                     {leftLabel}
-                </Name>
+                </text>
             ) : undefined}
             {children}
             {rightLabel !== undefined ? (
-                <Name
+                <text
+                    className="ej-seatmaps-row__name"
                     x={15}
                     y={5}
                     style={rightStyle}
                 >
                     {rightLabel}
-                </Name>
+                </text>
             ) : undefined}
         </g>
     );

--- a/packages/seatmaps/src/Seat.css
+++ b/packages/seatmaps/src/Seat.css
@@ -1,0 +1,55 @@
+@keyframes ej-seatmaps-seat-active {
+    from {
+        stroke-dashoffset: 0;
+    }
+    to {
+        stroke-dashoffset: 7;
+    }
+}
+
+.ej-seatmaps-seat {
+    cursor: default;
+}
+
+.ej-seatmaps-seat rect,
+.ej-seatmaps-seat circle {
+    stroke-width: 0.5;
+    stroke: white;
+}
+
+.ej-seatmaps-seat--clickable {
+    cursor: pointer;
+}
+
+.ej-seatmaps-seat--name-hidden .ej-seatmaps-seat__name {
+    display: none;
+}
+
+.ej-seatmaps-seat--name-hidden:hover .ej-seatmaps-seat__name {
+    display: block;
+}
+
+.ej-seatmaps-seat--active .ej-seatmaps-seat__name {
+    display: block;
+}
+
+.ej-seatmaps-seat--active rect,
+.ej-seatmaps-seat--active circle {
+    stroke-dasharray: 3, 4;
+    animation: ej-seatmaps-seat-active 1s linear infinite;
+    stroke: black;
+    stroke-width: 1;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.ej-seatmaps-seat__name {
+    font-family: sans-serif;
+    font-size: 5px;
+    text-anchor: middle;
+    alignment-baseline: central;
+    cursor: inherit;
+    fill: white;
+    dominant-baseline: mathematical;
+    display: block;
+}

--- a/packages/seatmaps/src/Seat.tsx
+++ b/packages/seatmaps/src/Seat.tsx
@@ -1,8 +1,7 @@
-import styled from '@emotion/styled';
-import { textCss } from './textCss';
 import { TextSize, useTextSize } from './textSize';
 import { useTransform } from './useTransform';
 import { noop } from './util/noop';
+import './Seat.css';
 
 /**
  * Available shapes for seat rendering.
@@ -38,61 +37,6 @@ const CircularSeat = ({ transform, fill }: ShapeComponentProps) => (
         fill={fill}
     />
 );
-
-const Name = styled('text')`
-    ${textCss}
-    text-anchor: middle;
-    alignment-baseline: central;
-    cursor: inherit;
-    fill: white;
-    dominant-baseline: mathematical;
-    display: block;
-`;
-
-const StyledSeat = styled.g`
-    @keyframes active-keyframes {
-        from {
-            stroke-dashoffset: 0;
-        }
-        to {
-            stroke-dashoffset: 7;
-        }
-    }
-
-    cursor: default;
-
-    rect,
-    circle {
-        stroke-width: 0.5;
-        stroke: white;
-    }
-
-    &.clickable {
-        cursor: pointer;
-    }
-
-    &.nameHidden .name {
-        display: none;
-    }
-
-    &.nameHidden:hover .name {
-        display: block;
-    }
-
-    &.active .name {
-        display: block;
-    }
-
-    &.active rect,
-    &.active circle {
-        stroke-dasharray: 3, 4;
-        animation: active-keyframes 1s linear infinite;
-        stroke: black;
-        stroke-width: 1;
-        stroke-linecap: round;
-        stroke-linejoin: round;
-    }
-`;
 
 /**
  * Props for the {@link Seat} component.
@@ -164,16 +108,19 @@ export const Seat = ({
         return color;
     })();
     const classNames = [
-        hideName ? 'nameHidden' : undefined,
-        onClick !== noop && !disabled ? 'clickable' : undefined,
-        active ? 'active' : undefined,
-    ];
+        'ej-seatmaps-seat',
+        hideName && 'ej-seatmaps-seat--name-hidden',
+        onClick !== noop && !disabled && 'ej-seatmaps-seat--clickable',
+        active && 'ej-seatmaps-seat--active',
+    ]
+        .filter(Boolean)
+        .join(' ');
     const handleClick = () => (disabled ? onDisabledClick : onClick)();
     const ShapeComponent = shape === SeatShape.CIRCLE ? CircularSeat : SquareSeat;
     const transform = useTransform(x + 2.5, y + 2.5);
     return (
-        <StyledSeat
-            className={classNames.join(' ')}
+        <g
+            className={classNames}
             onClick={handleClick}
         >
             <ShapeComponent
@@ -181,16 +128,16 @@ export const Seat = ({
                 fill={fill}
             />
             {name !== undefined ? (
-                <Name
+                <text
                     transform={textTransform}
                     x="5"
                     y="5"
-                    className="name"
+                    className="ej-seatmaps-seat__name"
                     style={textSize === TextSize.SMALL ? { fontSize: 4 } : undefined}
                 >
                     {name}
-                </Name>
+                </text>
             ) : undefined}
-        </StyledSeat>
+        </g>
     );
 };

--- a/packages/seatmaps/src/Text.css
+++ b/packages/seatmaps/src/Text.css
@@ -1,0 +1,3 @@
+.ej-seatmaps-text {
+    fill: #808080;
+}

--- a/packages/seatmaps/src/Text.tsx
+++ b/packages/seatmaps/src/Text.tsx
@@ -1,11 +1,7 @@
-import styled from '@emotion/styled';
 import { useTransform } from './useTransform';
+import './Text.css';
 
 const FONT_SIZE = 10;
-
-const Root = styled('text')`
-    fill: #808080;
-`;
 
 /**
  * Props for the {@link Text} component.
@@ -36,10 +32,11 @@ export interface TextProps {
  * @public
  */
 export const Text = ({ text, x = 0, y = 0, angle = 0 }: TextProps) => (
-    <Root
+    <text
+        className="ej-seatmaps-text"
         fontSize={FONT_SIZE}
         transform={useTransform(x, y + FONT_SIZE * 10, angle, 0, 0)}
     >
         {text}
-    </Root>
+    </text>
 );

--- a/packages/seatmaps/src/Volume.css
+++ b/packages/seatmaps/src/Volume.css
@@ -1,0 +1,36 @@
+@keyframes ej-seatmaps-volume-active {
+    from {
+        stroke-dashoffset: 0;
+    }
+    to {
+        stroke-dashoffset: 7;
+    }
+}
+
+.ej-seatmaps-volume {
+    cursor: default;
+}
+
+.ej-seatmaps-volume--clickable {
+    cursor: pointer;
+}
+
+.ej-seatmaps-volume--active .ej-seatmaps-volume__shape {
+    stroke-dasharray: 3, 4;
+    animation: ej-seatmaps-volume-active 1s linear infinite;
+    stroke: black;
+    stroke-width: 1;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.ej-seatmaps-volume__name {
+    font-family: sans-serif;
+    font-size: 5px;
+    dominant-baseline: central;
+    fill: black;
+}
+
+.ej-seatmaps-volume__scrim {
+    fill: rgba(255, 255, 255, 0.54);
+}

--- a/packages/seatmaps/src/Volume.tsx
+++ b/packages/seatmaps/src/Volume.tsx
@@ -1,48 +1,11 @@
-import styled from '@emotion/styled';
 import { CSSProperties, ReactNode, useEffect, useRef, useState } from 'react';
 import { l } from './length';
-import { textCss } from './textCss';
 import { useTransform } from './useTransform';
 import { noop } from './util/noop';
+import './Volume.css';
 
 const SCRIM_HEIGHT = 8;
 const HORIZONTAL_SCRIM_PADDING = 3;
-
-const StyledRoot = styled.g`
-    @keyframes active-keyframes {
-        from {
-            stroke-dashoffset: 0;
-        }
-        to {
-            stroke-dashoffset: 7;
-        }
-    }
-
-    cursor: default;
-
-    &.clickable {
-        cursor: pointer;
-    }
-
-    &.active .shape {
-        stroke-dasharray: 3, 4;
-        animation: active-keyframes 1s linear infinite;
-        stroke: black;
-        stroke-width: 1;
-        stroke-linecap: round;
-        stroke-linejoin: round;
-    }
-`;
-
-const Name = styled('text')`
-    ${textCss}
-    dominant-baseline: central;
-    fill: black;
-`;
-
-const StyledScrim = styled.rect`
-    fill: rgba(255, 255, 255, 0.54);
-`;
 
 interface ScrimProps {
     anchor?: 'center' | 'bottom-left';
@@ -74,19 +37,21 @@ const Scrim = ({ width = 'auto', x, y, text, anchor = 'bottom-left' }: ScrimProp
     const actualY = anchor === 'bottom-left' ? y - SCRIM_HEIGHT : y - SCRIM_HEIGHT / 2;
     return (
         <>
-            <StyledScrim
+            <rect
+                className="ej-seatmaps-volume__scrim"
                 width={scrimWidth}
                 height={SCRIM_HEIGHT}
                 x={actualX}
                 y={actualY}
             />
-            <Name
+            <text
+                className="ej-seatmaps-volume__name"
                 x={actualX + HORIZONTAL_SCRIM_PADDING}
                 y={actualY + SCRIM_HEIGHT / 2}
                 ref={textRef}
             >
                 {text}
-            </Name>
+            </text>
         </>
     );
 };
@@ -139,10 +104,10 @@ const EllipseVolume = ({
     children,
     fontWeight = 'bold',
 }: VolumeProps) => (
-    <StyledRoot
+    <g
+        className={className}
         transform={useTransform(x, y, angle, width, height)}
         onClick={onClick}
-        className={className}
         style={{ fontWeight: fontWeight }}
         fill={color}
     >
@@ -151,7 +116,7 @@ const EllipseVolume = ({
             ry={l(height / 2)}
             cx={l(width / 2)}
             cy={l(height / 2)}
-            className="shape"
+            className="ej-seatmaps-volume__shape"
         />
         {label !== undefined ? (
             <Scrim
@@ -163,7 +128,7 @@ const EllipseVolume = ({
             />
         ) : undefined}
         {children}
-    </StyledRoot>
+    </g>
 );
 
 const RectangleVolume = ({
@@ -179,10 +144,10 @@ const RectangleVolume = ({
     children,
     fontWeight = 'bold',
 }: VolumeProps) => (
-    <StyledRoot
+    <g
+        className={className}
         transform={useTransform(x, y, angle, width, height)}
         onClick={onClick}
-        className={className}
         style={{ fontWeight: fontWeight }}
         fill={color}
     >
@@ -191,7 +156,7 @@ const RectangleVolume = ({
             height={l(height)}
             rx={2}
             ry={2}
-            className="shape"
+            className="ej-seatmaps-volume__shape"
         />
         {label !== undefined ? (
             <Scrim
@@ -203,7 +168,7 @@ const RectangleVolume = ({
             />
         ) : undefined}
         {children}
-    </StyledRoot>
+    </g>
 );
 
 /**
@@ -235,10 +200,13 @@ export const Volume = (props: VolumeProps) => {
     const updatedProps: VolumeProps = {
         ...props,
         className: [
+            'ej-seatmaps-volume',
             props.className,
-            props.onClick !== noop ? 'clickable' : undefined,
-            props.active ? 'active' : undefined,
-        ].join(' '),
+            props.onClick !== noop && 'ej-seatmaps-volume--clickable',
+            props.active && 'ej-seatmaps-volume--active',
+        ]
+            .filter(Boolean)
+            .join(' '),
         color: (() => {
             if (props.disabled) {
                 return '#cccccc';

--- a/packages/seatmaps/src/textCss.ts
+++ b/packages/seatmaps/src/textCss.ts
@@ -1,6 +1,0 @@
-import { css } from '@emotion/react';
-
-export const textCss = css`
-    font-family: sans-serif;
-    font-size: 5px;
-`;

--- a/packages/seatmaps/tsup.config.ts
+++ b/packages/seatmaps/tsup.config.ts
@@ -6,5 +6,5 @@ export default defineConfig({
     dts: true,
     sourcemap: true,
     clean: true,
-    external: ['react', 'react-dom', 'react/jsx-runtime', '@emotion/react', '@emotion/styled'],
+    external: ['react', 'react-dom', 'react/jsx-runtime'],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,12 +25,6 @@ importers:
 
   packages/seatmaps:
     devDependencies:
-      "@emotion/react":
-        specifier: ^11.10.0
-        version: 11.14.0(@types/react@18.3.28)(react@18.3.1)
-      "@emotion/styled":
-        specifier: ^11.10.0
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
       "@eslint/js":
         specifier: ^9.0.0
         version: 9.39.2
@@ -320,99 +314,6 @@ packages:
     resolution:
       {
         integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==,
-      }
-
-  "@emotion/babel-plugin@11.13.5":
-    resolution:
-      {
-        integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==,
-      }
-
-  "@emotion/cache@11.14.0":
-    resolution:
-      {
-        integrity: sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==,
-      }
-
-  "@emotion/hash@0.9.2":
-    resolution:
-      {
-        integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==,
-      }
-
-  "@emotion/is-prop-valid@1.4.0":
-    resolution:
-      {
-        integrity: sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==,
-      }
-
-  "@emotion/memoize@0.9.0":
-    resolution:
-      {
-        integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==,
-      }
-
-  "@emotion/react@11.14.0":
-    resolution:
-      {
-        integrity: sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==,
-      }
-    peerDependencies:
-      "@types/react": "*"
-      react: ">=16.8.0"
-    peerDependenciesMeta:
-      "@types/react":
-        optional: true
-
-  "@emotion/serialize@1.3.3":
-    resolution:
-      {
-        integrity: sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==,
-      }
-
-  "@emotion/sheet@1.4.0":
-    resolution:
-      {
-        integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==,
-      }
-
-  "@emotion/styled@11.14.1":
-    resolution:
-      {
-        integrity: sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==,
-      }
-    peerDependencies:
-      "@emotion/react": ^11.0.0-rc.0
-      "@types/react": "*"
-      react: ">=16.8.0"
-    peerDependenciesMeta:
-      "@types/react":
-        optional: true
-
-  "@emotion/unitless@0.10.0":
-    resolution:
-      {
-        integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==,
-      }
-
-  "@emotion/use-insertion-effect-with-fallbacks@1.2.0":
-    resolution:
-      {
-        integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==,
-      }
-    peerDependencies:
-      react: ">=16.8.0"
-
-  "@emotion/utils@1.4.2":
-    resolution:
-      {
-        integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==,
-      }
-
-  "@emotion/weak-memoize@0.4.0":
-    resolution:
-      {
-        integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==,
       }
 
   "@esbuild/aix-ppc64@0.21.5":
@@ -2108,12 +2009,6 @@ packages:
         integrity: sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==,
       }
 
-  "@types/parse-json@4.0.2":
-    resolution:
-      {
-        integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==,
-      }
-
   "@types/prop-types@15.7.15":
     resolution:
       {
@@ -2537,13 +2432,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  babel-plugin-macros@3.1.0:
-    resolution:
-      {
-        integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==,
-      }
-    engines: { node: ">=10", npm: ">=6" }
-
   balanced-match@1.0.2:
     resolution:
       {
@@ -2762,24 +2650,11 @@ packages:
       }
     engines: { node: ^14.18.0 || >=16.10.0 }
 
-  convert-source-map@1.9.0:
-    resolution:
-      {
-        integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==,
-      }
-
   convert-source-map@2.0.0:
     resolution:
       {
         integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
       }
-
-  cosmiconfig@7.1.0:
-    resolution:
-      {
-        integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==,
-      }
-    engines: { node: ">=10" }
 
   cross-spawn@7.0.6:
     resolution:
@@ -2998,12 +2873,6 @@ packages:
         integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==,
       }
     engines: { node: ">=18" }
-
-  error-ex@1.3.4:
-    resolution:
-      {
-        integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==,
-      }
 
   es-abstract@1.24.1:
     resolution:
@@ -3303,12 +3172,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  find-root@1.1.0:
-    resolution:
-      {
-        integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==,
-      }
-
   find-up@5.0.0:
     resolution:
       {
@@ -3550,12 +3413,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  hoist-non-react-statics@3.3.2:
-    resolution:
-      {
-        integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==,
-      }
-
   html-encoding-sniffer@4.0.0:
     resolution:
       {
@@ -3667,12 +3524,6 @@ packages:
         integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==,
       }
     engines: { node: ">= 0.4" }
-
-  is-arrayish@0.2.1:
-    resolution:
-      {
-        integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==,
-      }
 
   is-async-function@2.1.1:
     resolution:
@@ -3987,12 +3838,6 @@ packages:
     resolution:
       {
         integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==,
-      }
-
-  json-parse-even-better-errors@2.3.1:
-    resolution:
-      {
-        integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==,
       }
 
   json-schema-traverse@0.4.1:
@@ -4446,13 +4291,6 @@ packages:
       }
     engines: { node: ">=6" }
 
-  parse-json@5.2.0:
-    resolution:
-      {
-        integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==,
-      }
-    engines: { node: ">=8" }
-
   parse5@7.3.0:
     resolution:
       {
@@ -4492,13 +4330,6 @@ packages:
         integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==,
       }
     engines: { node: ">=16 || 14 >=14.18" }
-
-  path-type@4.0.0:
-    resolution:
-      {
-        integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==,
-      }
-    engines: { node: ">=8" }
 
   pathe@1.1.2:
     resolution:
@@ -4997,13 +4828,6 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
-  source-map@0.5.7:
-    resolution:
-      {
-        integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==,
-      }
-    engines: { node: ">=0.10.0" }
-
   source-map@0.6.1:
     resolution:
       {
@@ -5172,12 +4996,6 @@ packages:
         integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==,
       }
     engines: { node: ">=14.16" }
-
-  stylis@4.2.0:
-    resolution:
-      {
-        integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==,
-      }
 
   sucrase@3.35.1:
     resolution:
@@ -5767,13 +5585,6 @@ packages:
         integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==,
       }
 
-  yaml@1.10.2:
-    resolution:
-      {
-        integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==,
-      }
-    engines: { node: ">= 6" }
-
   yaml@2.8.2:
     resolution:
       {
@@ -5955,89 +5766,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
-
-  "@emotion/babel-plugin@11.13.5":
-    dependencies:
-      "@babel/helper-module-imports": 7.28.6
-      "@babel/runtime": 7.28.6
-      "@emotion/hash": 0.9.2
-      "@emotion/memoize": 0.9.0
-      "@emotion/serialize": 1.3.3
-      babel-plugin-macros: 3.1.0
-      convert-source-map: 1.9.0
-      escape-string-regexp: 4.0.0
-      find-root: 1.1.0
-      source-map: 0.5.7
-      stylis: 4.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  "@emotion/cache@11.14.0":
-    dependencies:
-      "@emotion/memoize": 0.9.0
-      "@emotion/sheet": 1.4.0
-      "@emotion/utils": 1.4.2
-      "@emotion/weak-memoize": 0.4.0
-      stylis: 4.2.0
-
-  "@emotion/hash@0.9.2": {}
-
-  "@emotion/is-prop-valid@1.4.0":
-    dependencies:
-      "@emotion/memoize": 0.9.0
-
-  "@emotion/memoize@0.9.0": {}
-
-  "@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1)":
-    dependencies:
-      "@babel/runtime": 7.28.6
-      "@emotion/babel-plugin": 11.13.5
-      "@emotion/cache": 11.14.0
-      "@emotion/serialize": 1.3.3
-      "@emotion/use-insertion-effect-with-fallbacks": 1.2.0(react@18.3.1)
-      "@emotion/utils": 1.4.2
-      "@emotion/weak-memoize": 0.4.0
-      hoist-non-react-statics: 3.3.2
-      react: 18.3.1
-    optionalDependencies:
-      "@types/react": 18.3.28
-    transitivePeerDependencies:
-      - supports-color
-
-  "@emotion/serialize@1.3.3":
-    dependencies:
-      "@emotion/hash": 0.9.2
-      "@emotion/memoize": 0.9.0
-      "@emotion/unitless": 0.10.0
-      "@emotion/utils": 1.4.2
-      csstype: 3.2.3
-
-  "@emotion/sheet@1.4.0": {}
-
-  "@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)":
-    dependencies:
-      "@babel/runtime": 7.28.6
-      "@emotion/babel-plugin": 11.13.5
-      "@emotion/is-prop-valid": 1.4.0
-      "@emotion/react": 11.14.0(@types/react@18.3.28)(react@18.3.1)
-      "@emotion/serialize": 1.3.3
-      "@emotion/use-insertion-effect-with-fallbacks": 1.2.0(react@18.3.1)
-      "@emotion/utils": 1.4.2
-      react: 18.3.1
-    optionalDependencies:
-      "@types/react": 18.3.28
-    transitivePeerDependencies:
-      - supports-color
-
-  "@emotion/unitless@0.10.0": {}
-
-  "@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@18.3.1)":
-    dependencies:
-      react: 18.3.1
-
-  "@emotion/utils@1.4.2": {}
-
-  "@emotion/weak-memoize@0.4.0": {}
 
   "@esbuild/aix-ppc64@0.21.5":
     optional: true
@@ -6912,8 +6640,6 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  "@types/parse-json@4.0.2": {}
-
   "@types/prop-types@15.7.15": {}
 
   "@types/react-dom@18.3.7(@types/react@18.3.28)":
@@ -7232,12 +6958,6 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  babel-plugin-macros@3.1.0:
-    dependencies:
-      "@babel/runtime": 7.28.6
-      cosmiconfig: 7.1.0
-      resolve: 1.22.11
-
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.9.19: {}
@@ -7354,17 +7074,7 @@ snapshots:
 
   consola@3.4.2: {}
 
-  convert-source-map@1.9.0: {}
-
   convert-source-map@2.0.0: {}
-
-  cosmiconfig@7.1.0:
-    dependencies:
-      "@types/parse-json": 4.0.2
-      import-fresh: 3.3.1
-      parse-json: 5.2.0
-      path-type: 4.0.0
-      yaml: 1.10.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -7469,10 +7179,6 @@ snapshots:
   entities@6.0.1: {}
 
   environment@1.1.0: {}
-
-  error-ex@1.3.4:
-    dependencies:
-      is-arrayish: 0.2.1
 
   es-abstract@1.24.1:
     dependencies:
@@ -7824,8 +7530,6 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  find-root@1.1.0: {}
-
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -7971,10 +7675,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hoist-non-react-statics@3.3.2:
-    dependencies:
-      react-is: 16.13.1
-
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
@@ -8034,8 +7734,6 @@ snapshots:
       call-bind: 1.0.8
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
-
-  is-arrayish@0.2.1: {}
 
   is-async-function@2.1.1:
     dependencies:
@@ -8223,8 +7921,6 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
-
-  json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
 
@@ -8519,13 +8215,6 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
-  parse-json@5.2.0:
-    dependencies:
-      "@babel/code-frame": 7.29.0
-      error-ex: 1.3.4
-      json-parse-even-better-errors: 2.3.1
-      lines-and-columns: 1.2.4
-
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -8542,8 +8231,6 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
-
-  path-type@4.0.0: {}
 
   pathe@1.1.2: {}
 
@@ -8868,8 +8555,6 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map@0.5.7: {}
-
   source-map@0.6.1: {}
 
   source-map@0.7.6: {}
@@ -8980,8 +8665,6 @@ snapshots:
   strip-json-comments@3.1.1: {}
 
   strip-json-comments@5.0.3: {}
-
-  stylis@4.2.0: {}
 
   sucrase@3.35.1:
     dependencies:
@@ -9362,8 +9045,6 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
-
-  yaml@1.10.2: {}
 
   yaml@2.8.2: {}
 


### PR DESCRIPTION
## Summary

- Replace Emotion CSS-in-JS with static CSS files
- Remove `@emotion/react` and `@emotion/styled` peer dependencies
- Add bundled CSS export at `@eventjet/react-seatmaps/styles.css`
- Use BEM-style class names with `ej-seatmaps-` prefix to avoid conflicts

## Breaking Change

Consumers must now import the stylesheet separately:

```typescript
import { Seat, Volume } from '@eventjet/react-seatmaps';
import '@eventjet/react-seatmaps/styles.css';
```

## Why

- Zero runtime overhead (static CSS vs CSS-in-JS)
- Smaller bundle size (no Emotion runtime)
- Standard, future-proof approach

## Test plan

- [x] `pnpm build` - produces `dist/index.css`
- [x] `pnpm typecheck` - passes
- [x] `pnpm test` - passes
- [x] `pnpm lint` - passes
- [x] `pnpm api:check` - API unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)