### PR TITLE
Fix CJS __toESM interop bug with @emotion/styled in Jest

### DIFF
--- a/packages/seatmaps/tsup.config.ts
+++ b/packages/seatmaps/tsup.config.ts
@@ -19,6 +19,30 @@ const reactCompilerPlugin: Plugin = {
     },
 };
 
+/**
+ * esbuild's CJS output wraps default imports of external ESM-flagged packages with
+ * `__toESM(require("pkg"), 1)`. The `isNodeMode=1` argument makes `__toESM` set
+ * `target.default = mod` (the whole exports object), ignoring `mod.__esModule`.
+ * For packages like @emotion/styled that use `{ __esModule: true, default: fn }`,
+ * this means `import_styled.default` is the exports object instead of the function,
+ * causing runtime errors. Removing `isNodeMode` from the condition lets __copyProps
+ * correctly pick up `mod.default` when `mod.__esModule` is true.
+ */
+const fixCjsDefaultInteropPlugin: Plugin = {
+    name: 'fix-cjs-default-interop',
+    setup(build) {
+        if (build.initialOptions.format !== 'cjs') return;
+        build.onEnd((result) => {
+            if (!result.outputFiles) return;
+            for (const file of result.outputFiles) {
+                if (!file.path.endsWith('.cjs')) continue;
+                const fixed = file.text.replace('isNodeMode || !mod || !mod.__esModule', '!mod || !mod.__esModule');
+                file.contents = Buffer.from(fixed, 'utf8');
+            }
+        });
+    },
+};
+
 export default defineConfig({
     entry: ['src/index.ts'],
     format: ['cjs', 'esm'],
@@ -26,5 +50,5 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
     external: ['react', 'react-dom', 'react/jsx-runtime', '@emotion/react', '@emotion/styled'],
-    esbuildPlugins: [reactCompilerPlugin],
+    esbuildPlugins: [reactCompilerPlugin, fixCjsDefaultInteropPlugin],
 });


### PR DESCRIPTION
## Summary

- esbuild generates `__toESM(require("@emotion/styled"), 1)` in the CJS build; the `isNodeMode=1` argument forces `target.default = mod` (the whole exports object `{ __esModule: true, default: styledFn }`) instead of `mod.default` (the actual styled function)
- This means `import_styled.default.g` (`styled.div` etc., minified) is `undefined` at runtime → TypeError when consumers use the `.cjs` entry in Jest
- Fixed by adding an esbuild `onEnd` plugin (`fixCjsDefaultInteropPlugin`) that patches the `__toESM` helper in the CJS output: removes `isNodeMode` from the condition so `__copyProps` correctly picks up `mod.default` when `mod.__esModule` is true — matching TypeScript's own `__importDefault` behaviour

## Details

The generated `__toESM` condition was:
```js
isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod }) : target
```

With `isNodeMode=1`, this always sets `target.default = mod` (the exports object), ignoring `mod.__esModule`. The fix changes it to:
```js
!mod || !mod.__esModule ? __defProp(target, "default", { value: mod }) : target
```

Pure CJS packages (no `__esModule` flag, e.g. `lodash`) are unaffected. Packages using the `{ __esModule: true, default: fn }` convention (all `@emotion/*` packages) now correctly expose `default` as the function.

Note: setting `platform: 'neutral'` in tsup does not fix this — esbuild still generates `isNodeMode=1` when bundling actual TypeScript source files, regardless of the platform setting.

## Test plan

- [x] `pnpm build` succeeds and CJS output has the corrected `__toESM` definition
- [x] `node -e "require('./dist/index.cjs')"` runs without error (previously would fail when styled components are initialized)
- [x] `pnpm test` — all 66 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)