### PR TITLE
fix: correct coordinate scaling description in README

### DIFF
--- a/packages/seatmaps/README.md
+++ b/packages/seatmaps/README.md
@@ -253,7 +253,7 @@ Generic circular badge component.
 
 ## Coordinate System
 
-All coordinates are scaled by a factor of 10 internally. For example, `x={100}` becomes `10` in the rendered SVG.
+All coordinates are divided by 10 internally. For example, `x={100}` becomes `10` in the rendered SVG.
 
 ## License
 


### PR DESCRIPTION
The coordinate system docs said 'scaled by a factor of 10' but the example shows division by 10 (`x={100}` → `10`). 'Scaled by a factor of 10' implies multiplication. Fixed to 'divided by 10'.