### PR TITLE
chore: exclude CHANGELOG.md from Prettier

### DIFF
--- a/packages/seatmaps/.prettierignore
+++ b/packages/seatmaps/.prettierignore
@@ -1,4 +1,5 @@
 api/
+CHANGELOG.md
 lib/
 node_modules/
 temp/


### PR DESCRIPTION
release-please generates `CHANGELOG.md` with its own formatting that doesn't match Prettier's output, causing CI to fail on `format:check` after every release.