### PR TITLE
fix: use releases_created output for config-file based release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -22,7 +22,7 @@ jobs:
 
   publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.releases_created }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
When using `release-please-config.json` with a `packages` key, the action sets `releases_created` (plural) not `release_created` (singular). The `publish` job was silently skipped on every release because it checked the wrong output name — this is why `2.0.2` never made it to npm.