### PR TITLE
chore: add workflow_dispatch to allow manual publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -22,7 +23,7 @@ jobs:
 
   publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created }}
+    if: ${{ needs.release-please.outputs.releases_created || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Adds a manual trigger to the Release workflow so the publish job can be re-run if it's ever skipped or fails after a release (e.g. the `2.0.2` situation).

On manual dispatch the `release-please` job runs as a noop; the `publish` job condition is satisfied via `github.event_name == 'workflow_dispatch'` instead of `releases_created`.