### PR TITLE
docs: document manual publish via workflow_dispatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,3 +99,5 @@ Use [Conventional Commits](https://www.conventionalcommits.org/) format — rele
 Releases are fully automated. After merging to `master`, release-please opens a Release PR that bumps `package.json` and updates `CHANGELOG.md`. Merging the Release PR creates the GitHub Release, which triggers CI to publish to npm.
 
 **Never manually create GitHub Releases or edit `package.json` version** — let release-please manage both. The current published version is always visible in `.release-please-manifest.json`.
+
+If the publish job is ever skipped or fails, trigger it manually via **Actions → Release → Run workflow** on `master`.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ After every merge to `master`, release-please opens or updates a **Release PR** 
 
 When you're ready to release, **merge the Release PR**. release-please then creates a GitHub Release and the publish job runs automatically.
 
+### Re-publishing manually
+
+If the publish job is ever skipped or fails after a release, go to **Actions → Release → Run workflow** and trigger it on `master`. It will publish whatever version is in `packages/seatmaps/package.json`.
+
 ### Commit message format
 
 release-please determines the version bump from commit messages using [Conventional Commits](https://www.conventionalcommits.org/):


### PR DESCRIPTION
Adds a note to both README and AGENTS.md explaining how to re-publish manually if the publish job is ever skipped or fails after a release.