### PR TITLE
fix: work around Dependabot not supporting pnpm lockfileVersion 9.0

### DIFF
--- a/.github/workflows/check-dependabot-fix.yml
+++ b/.github/workflows/check-dependabot-fix.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          state=$(gh issue view 13920 --repo dependabot/dependabot-core --json state --jq '.state')
+          state=$(GH_TOKEN= gh issue view 13920 --repo dependabot/dependabot-core --json state --jq '.state')
           if [ "$state" = "OPEN" ]; then
             echo "Upstream issue is still open, nothing to do."
             exit 0

--- a/.github/workflows/check-dependabot-fix.yml
+++ b/.github/workflows/check-dependabot-fix.yml
@@ -36,18 +36,20 @@ jobs:
             exit 0
           fi
 
+          body_file=$(mktemp)
+          printf '%s\n' \
+            'dependabot/dependabot-core#13920 has been resolved.' \
+            '' \
+            'The lockfile regeneration workaround is no longer needed. Remove:' \
+            '- `.github/workflows/dependabot-lockfile.yml`' \
+            '- `.github/workflows/check-dependabot-fix.yml`' \
+            '' \
+            'Then verify that Dependabot PRs correctly update `pnpm-lock.yaml` on their own.' \
+            > "$body_file"
+
           gh issue create --repo "${{ github.repository }}" \
             --assignee MidnightDesign \
             --title "Remove Dependabot lockfile workaround" \
-            --body "$(cat <<'EOF'
-          dependabot/dependabot-core#13920 has been resolved.
-
-          The lockfile regeneration workaround is no longer needed. Remove:
-          - `.github/workflows/dependabot-lockfile.yml`
-          - `.github/workflows/check-dependabot-fix.yml`
-
-          Then verify that Dependabot PRs correctly update `pnpm-lock.yaml` on their own.
-          EOF
-          )"
+            --body-file "$body_file"
 
           echo "Created reminder issue."

--- a/.github/workflows/check-dependabot-fix.yml
+++ b/.github/workflows/check-dependabot-fix.yml
@@ -11,6 +11,9 @@ on:
   schedule:
     - cron: "0 9 * * 1" # Every Monday at 9:00 UTC
 
+permissions:
+  issues: write
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -27,7 +30,7 @@ jobs:
 
           echo "Upstream issue is no longer open (state: $state)."
 
-          existing=$(gh issue list --repo "${{ github.repository }}" --search "Remove Dependabot lockfile workaround" --json number --jq 'length')
+          existing=$(gh issue list --repo "${{ github.repository }}" --state open --search "Remove Dependabot lockfile workaround" --json number --jq 'length')
           if [ "$existing" != "0" ]; then
             echo "Reminder issue already exists, skipping."
             exit 0

--- a/.github/workflows/check-dependabot-fix.yml
+++ b/.github/workflows/check-dependabot-fix.yml
@@ -1,0 +1,50 @@
+# Checks weekly whether the upstream Dependabot issue for pnpm lockfileVersion
+# 9.0 support has been resolved. Creates a repo issue (assigned to @MidnightDesign)
+# when it detects the fix, so we remember to remove the workaround.
+#
+# Related: https://github.com/dependabot/dependabot-core/issues/13920
+# Remove this workflow together with dependabot-lockfile.yml once the issue is resolved.
+
+name: Check Dependabot pnpm Fix
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Every Monday at 9:00 UTC
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if upstream issue is resolved
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          state=$(gh issue view 13920 --repo dependabot/dependabot-core --json state --jq '.state')
+          if [ "$state" = "OPEN" ]; then
+            echo "Upstream issue is still open, nothing to do."
+            exit 0
+          fi
+
+          echo "Upstream issue is no longer open (state: $state)."
+
+          existing=$(gh issue list --repo "${{ github.repository }}" --search "Remove Dependabot lockfile workaround" --json number --jq 'length')
+          if [ "$existing" != "0" ]; then
+            echo "Reminder issue already exists, skipping."
+            exit 0
+          fi
+
+          gh issue create --repo "${{ github.repository }}" \
+            --assignee MidnightDesign \
+            --title "Remove Dependabot lockfile workaround" \
+            --body "$(cat <<'EOF'
+          dependabot/dependabot-core#13920 has been resolved.
+
+          The lockfile regeneration workaround is no longer needed. Remove:
+          - `.github/workflows/dependabot-lockfile.yml`
+          - `.github/workflows/check-dependabot-fix.yml`
+
+          Then verify that Dependabot PRs correctly update `pnpm-lock.yaml` on their own.
+          EOF
+          )"
+
+          echo "Created reminder issue."

--- a/.github/workflows/check-dependabot-fix.yml
+++ b/.github/workflows/check-dependabot-fix.yml
@@ -22,6 +22,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           state=$(GH_TOKEN= gh issue view 13920 --repo dependabot/dependabot-core --json state --jq '.state')
           if [ "$state" = "OPEN" ]; then
             echo "Upstream issue is still open, nothing to do."

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,0 +1,43 @@
+# Workaround for https://github.com/dependabot/dependabot-core/issues/13920
+# Dependabot can't parse pnpm lockfileVersion 9.0, so it updates package.json
+# but not pnpm-lock.yaml. This workflow regenerates the lockfile and commits it.
+#
+# Remove this workflow once the upstream issue is resolved.
+
+name: Fix Dependabot Lockfile
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  fix-lockfile:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: pnpm
+
+      - run: pnpm install --no-frozen-lockfile
+
+      - name: Commit updated lockfile
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pnpm-lock.yaml
+          git diff --cached --quiet || git commit -m "chore: update pnpm-lock.yaml"
+          git push

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -39,5 +39,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add pnpm-lock.yaml
-          git diff --cached --quiet || git commit -m "chore: update pnpm-lock.yaml"
-          git push
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: update pnpm-lock.yaml"
+            git push origin HEAD:${{ github.head_ref }}
+          fi

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   fix-lockfile:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: "20"
           cache: pnpm
 
-      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm install --lockfile-only --no-frozen-lockfile
 
       - name: Commit updated lockfile
         run: |


### PR DESCRIPTION
## Summary

- Add a workflow that regenerates `pnpm-lock.yaml` on Dependabot PRs, working around [dependabot/dependabot-core#13920](https://github.com/dependabot/dependabot-core/issues/13920) (Dependabot can't parse lockfileVersion 9.0)
- Add a weekly scheduled check that creates a reminder issue (assigned to @MidnightDesign) once the upstream bug is resolved, so we don't forget to remove the workaround

## Affected PRs

The following Dependabot PRs are currently failing because of this issue:

- #51 — Bump typescript from 5.9.3 to 6.0.2 in /packages/seatmaps
- #53 — Bump esbuild from 0.27.4 to 0.28.0 in /packages/seatmaps
- #54 — Bump the dev-tooling group across 1 directory with 11 updates

## Test plan

- [ ] Verify the lockfile workflow triggers on the next Dependabot PR and commits an updated `pnpm-lock.yaml`
- [ ] Verify CI passes after the lockfile is regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
